### PR TITLE
chore: drop matplotlib upper bound pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
 	"cdsapi>=0.6.1",
 	"ecape-parcel>=1.2.0.2",
-	"matplotlib>=3.3.0, <=3.7.1",
+	"matplotlib>=3.3.0",
 	"metpy>=1.5.1",
 	"netcdf4>=1.6.4",
 	"numpy>=1.20.0",


### PR DESCRIPTION
closes #24