### PR TITLE
Add optional inflow visualization

### DIFF
--- a/src/sounderpy/calc.py
+++ b/src/sounderpy/calc.py
@@ -139,10 +139,11 @@ def dcape_calc(pressure, temperature, dewpoint):
 class sounding_params:
 
 
-    def __init__(self, clean_data, storm_motion='right_moving', modify_sfc=None):
+    def __init__(self, clean_data, storm_motion='right_moving', modify_sfc=None, include_all_parcels=False):
             self.clean_data = clean_data 
             self.storm_motion = storm_motion
             self.modify_sfc = modify_sfc
+            self.include_all_parcels = include_all_parcels
 
             
     ######################################################################################################
@@ -394,6 +395,14 @@ class sounding_params:
             thermo['dparcel_p'] = ma.masked
             thermo['dparcel_T'] = ma.masked
 
+        #--- PARCEL PROFILES ---#
+        # ---------------------------------------------------------------
+
+        if self.include_all_parcels:
+            parcels = [parcelx(prof, pres=p[i].m, tmpc=T[i].m, dwpc=Td[i].m) for i in range(len(p))]
+            thermo['cape_profile'] = np.array([pcl.bplus for pcl in parcels])
+            thermo['cin_profile'] = np.array([pcl.bminus for pcl in parcels])
+            thermo['3cape_profile'] = np.array([pcl.b3km for pcl in parcels])
 
 
         # ENTRAINING CAPE NOW LOCATED BELOW KINEMATICS SECTION SO 

--- a/src/sounderpy/plot.py
+++ b/src/sounderpy/plot.py
@@ -215,7 +215,7 @@ def __full_sounding(clean_data, color_blind, dark_mode, storm_motion, special_pa
     ws = mpcalc.wind_speed(u, v) 
     
     # calculate other sounding parameters using SounderPy Calc
-    general, thermo, kinem, intrp = sounding_params(sounding_data, storm_motion, include_all_parcels=bool(show_inflow)).calc()
+    general, thermo, kinem, intrp = sounding_params(sounding_data, storm_motion, include_all_parcels=show_inflow).calc()
     #################################################################
     
     

--- a/src/sounderpy/sounderpy.py
+++ b/src/sounderpy/sounderpy.py
@@ -206,7 +206,7 @@ def get_bufkit_data(model, station, fcst_hour, run_year=None, run_month=None, ru
 #########################################################################
 def build_sounding(clean_data, style='full', color_blind=False, dark_mode=False, storm_motion='right_moving',
                    special_parcels=None, show_radar=True, radar_time='sounding', map_zoom=2, modify_sfc=None,
-                   save=False, filename='sounderpy_sounding'):
+                   show_inflow=False, save=False, filename='sounderpy_sounding'):
     
     '''
     Return a full sounding plot of SounderPy data, ``plt``
@@ -223,6 +223,7 @@ def build_sounding(clean_data, style='full', color_blind=False, dark_mode=False,
     :type storm_motion: str or list of floats, optional
     :param special_parcels: a nested list of special parcels from the ``ecape_parcels`` library. The nested list should be a list of two lists (`[[a, b], [c, d]]`) where the first list should include 'highlight parcels' and second list should include 'background parcels'. For more details, see the :ref:`parcels_logic` section.
     :type special_parcels: nested `list` of two `lists`, optional
+    :param show_inflow: bool, optional
     :param save: whether to show the plot inline or save to a file. Default is ``False`` which displays the file inline.
     :type save: bool, optional
     :param filename: the filename by which a file should be saved to if ``save = True``. Default is `sounderpy_sounding`.
@@ -233,10 +234,11 @@ def build_sounding(clean_data, style='full', color_blind=False, dark_mode=False,
     
     print(f'> SOUNDING PLOTTER FUNCTION\n  ---------------------------------')
 
+    plt = __full_sounding(clean_data, color_blind, dark_mode, storm_motion, special_parcels, show_radar, radar_time, map_zoom, modify_sfc, show_inflow)
     if save:
-        __full_sounding(clean_data, color_blind, dark_mode, storm_motion, special_parcels, show_radar, radar_time, map_zoom, modify_sfc).savefig(filename, bbox_inches='tight')
+        plt.savefig(filename, bbox_inches='tight')
     else:
-        __full_sounding(clean_data, color_blind, dark_mode, storm_motion, special_parcels, show_radar, radar_time, map_zoom, modify_sfc).show()
+        plt.show()
 
 
 


### PR DESCRIPTION
This PR adds a `show_inflow` option to the `build_sounding()` function which visualizes the CAPE, 3CAPE and CIN at each level of the atmosphere. 

The main use case is to quickly evaluate how strongly a storm is elevated or surface-based given different amounts of background forcing. The [effective inflow layer](https://journals.ametsoc.org/view/journals/mwre/148/8/mwrD200013.xml) is an approximation of the lowest contiguous layer of inflow shown in this visualization. 

Feel free to suggest or make any changes to this design.

Context: [Bluesky thread](https://bsky.app/profile/ryanvandersmith.com/post/3ldkhf2f5fs2u).

**Examples:**

2023 Yuma, CO EF3:

![image](https://github.com/user-attachments/assets/5cfa1cf8-5e94-4155-838f-06aa3c21abba)

2024 messy MCS / tornado bust near Lufkin, TX. Note the secondary inflow layer from 700-500mb:

![image](https://github.com/user-attachments/assets/c4435c09-c6ba-4d2f-b780-8ddf79552945)

2024 Shreveport, LA tornado associated with Hurricane Beryl:

![image](https://github.com/user-attachments/assets/882bdad0-7550-4a62-9d4e-a024bd7dfb43)

2024 surprise Lafayette, CO landspout:

![image](https://github.com/user-attachments/assets/08dfd088-fb9f-437b-97d1-c1a6123d3fca)

2024 Bedford, TX 2" hail event:

![image](https://github.com/user-attachments/assets/dc14e116-ef0d-4e18-a528-b3b8ec4f4f7f)

2022 QLCS near Lakeside, NE:

![image](https://github.com/user-attachments/assets/83468bfd-ba9e-4ac5-a7ad-c9e33461831c)

[2023 Akron, CO supercell](https://www.weather.gov/bou/tornadoes_june_21_2023) which produced 27 tornadoes:

![image](https://github.com/user-attachments/assets/afebaac9-c004-4332-a643-7e5c0407e9dc)

Dark mode:

![image](https://github.com/user-attachments/assets/cd8e656e-138a-4bd5-8172-5e8355edac57)
