### PR TITLE
Replace "Theta & Theta-e" 0-3km plot with "CIN & 3CAPE"

### DIFF
--- a/src/sounderpy/calc.py
+++ b/src/sounderpy/calc.py
@@ -139,10 +139,11 @@ def dcape_calc(pressure, temperature, dewpoint):
 class sounding_params:
 
 
-    def __init__(self, clean_data, storm_motion='right_moving', modify_sfc=None):
+    def __init__(self, clean_data, storm_motion='right_moving', modify_sfc=None, include_all_parcels=False):
             self.clean_data = clean_data 
             self.storm_motion = storm_motion
             self.modify_sfc = modify_sfc
+            self.include_all_parcels = include_all_parcels
 
             
     ######################################################################################################
@@ -394,6 +395,18 @@ class sounding_params:
             thermo['dparcel_p'] = ma.masked
             thermo['dparcel_T'] = ma.masked
 
+        #--- PARCEL PROFILES ---#
+        # ---------------------------------------------------------------
+        if self.include_all_parcels:
+            # Calculate parcels
+            parcels = [parcelx(prof, pres=p[i].m, tmpc=T[i].m, dwpc=Td[i].m) for i in range(len(p))]
+            thermo['cape_profile'] = np.array([pcl.bplus for pcl in parcels])
+            thermo['cin_profile'] = np.array([pcl.bminus for pcl in parcels])
+            thermo['3cape_profile'] = np.array([pcl.b3km for pcl in parcels])
+            # Interpolate
+            intrp['cape_profileINTRP'] = interpolate(thermo['cape_profile'], zINTRP, resolution)
+            intrp['cin_profileINTRP'] = interpolate(thermo['cin_profile'], zINTRP, resolution)
+            intrp['3cape_profileINTRP'] = interpolate(thermo['3cape_profile'], zINTRP, resolution)
 
 
         # ENTRAINING CAPE NOW LOCATED BELOW KINEMATICS SECTION SO 

--- a/src/sounderpy/plot.py
+++ b/src/sounderpy/plot.py
@@ -61,7 +61,8 @@ from .utils import modify_surface, find_nearest, mag, mag_round
 ########################## FULL SOUNDING ################################
 
 def __full_sounding(clean_data, color_blind, dark_mode, storm_motion, special_parcels=None, 
-                    show_radar=True, radar_time='sounding', map_zoom=2, modify_sfc=None):
+                    show_radar=True, radar_time='sounding', map_zoom=2, modify_sfc=None,
+                    show_theta=False):
     
     
     # record process time 
@@ -214,7 +215,7 @@ def __full_sounding(clean_data, color_blind, dark_mode, storm_motion, special_pa
     ws = mpcalc.wind_speed(u, v) 
     
     # calculate other sounding parameters using SounderPy Calc
-    general, thermo, kinem, intrp = sounding_params(sounding_data, storm_motion).calc()
+    general, thermo, kinem, intrp = sounding_params(sounding_data, storm_motion, include_all_parcels=not show_theta).calc()
     #################################################################
     
     
@@ -1202,44 +1203,86 @@ def __full_sounding(clean_data, color_blind, dark_mode, storm_motion, special_pa
     
     
     
-    #################################################################
-    ### THETA & THETA E W/HGT ###
-    #################################################################
-    #PLOT AXES/LOC
-    theta_ax = plt.axes((1.141, -0.13, 0.0653, 0.23))
-    plt.figtext(1.175, 0.06, f'Theta-e &\nTheta (K)', weight='bold', color=gen_txt_clr, fontsize=12, ha='center', alpha=0.7)
-    theta_ax.spines["top"].set_color(brdr_clr)
-    theta_ax.spines["left"].set_color(brdr_clr)
-    theta_ax.spines["right"].set_color(brdr_clr)
-    theta_ax.spines["bottom"].set_color(brdr_clr)
-    theta_ax.spines["bottom"].set_color(brdr_clr)   
-    theta_ax.set_facecolor(bckgrnd_clr) 
+    if show_theta:
+        #############################################################
+        ### THETA & THETA E W/HGT ###
+        #############################################################
+        #PLOT AXES/LOC
+        theta_ax = plt.axes((1.141, -0.13, 0.0653, 0.23))
+        plt.figtext(1.175, 0.06, f'Theta-e &\nTheta (K)', weight='bold', color=gen_txt_clr, fontsize=12, ha='center', alpha=0.7)
+        theta_ax.spines["top"].set_color(brdr_clr)
+        theta_ax.spines["left"].set_color(brdr_clr)
+        theta_ax.spines["right"].set_color(brdr_clr)
+        theta_ax.spines["bottom"].set_color(brdr_clr)
+        theta_ax.spines["bottom"].set_color(brdr_clr)   
+        theta_ax.set_facecolor(bckgrnd_clr) 
 
-    maxtheta = intrp['thetaeINTRP'][0:30].max()
-    mintheta = intrp['thetaINTRP'][0:30].min()
+        maxtheta = intrp['thetaeINTRP'][0:30].max()
+        mintheta = intrp['thetaINTRP'][0:30].min()
 
-    #YTICKS
-    theta_ax.set_ylim(intrp['zINTRP'][0], 3000)
-    theta_ax.set_yticklabels([])
-    plt.ylabel(' ')
-    theta_ax.tick_params(axis='y', length = 0)
-    theta_ax.grid(True, axis='y')
+        #YTICKS
+        theta_ax.set_ylim(intrp['zINTRP'][0], 3000)
+        theta_ax.set_yticklabels([])
+        plt.ylabel(' ')
+        theta_ax.tick_params(axis='y', length = 0)
+        theta_ax.grid(True, axis='y')
 
-    #XTICKS
-    theta_ax.set_xlim(mintheta - 5, maxtheta + 5)
-    theta_ax.set_xticks([(mintheta), (maxtheta)])
-    theta_ax.set_xticklabels([int(mintheta), int(maxtheta)], weight='bold', alpha=0.5, fontstyle='italic', color=gen_txt_clr)
+        #XTICKS
+        theta_ax.set_xlim(mintheta - 5, maxtheta + 5)
+        theta_ax.set_xticks([(mintheta), (maxtheta)])
+        theta_ax.set_xticklabels([int(mintheta), int(maxtheta)], weight='bold', alpha=0.5, fontstyle='italic', color=gen_txt_clr)
 
-    theta_ax.tick_params(axis="x", direction="in", pad=-12)
-    theta_ax.set_xlabel(' ')
+        theta_ax.tick_params(axis="x", direction="in", pad=-12)
+        theta_ax.set_xlabel(' ')
 
-    #PLOT THETA VS HGT
-    plt.plot(intrp['thetaINTRP'], intrp['zINTRP'], color='purple', linewidth=3.5, alpha=0.5, clip_on=True)
-    plt.plot(intrp['thetaeINTRP'], intrp['zINTRP'], color='purple', linewidth=3.5, alpha=0.8, clip_on=True)
+        #PLOT THETA VS HGT
+        plt.plot(intrp['thetaINTRP'], intrp['zINTRP'], color='purple', linewidth=3.5, alpha=0.5, clip_on=True)
+        plt.plot(intrp['thetaeINTRP'], intrp['zINTRP'], color='purple', linewidth=3.5, alpha=0.8, clip_on=True)
 
-    if ma.is_masked(kinem['eil_z'][0]) == False:
-        theta_ax.fill_between(x=(mintheta - 5, maxtheta + 5), y1=kinem['eil_z'][0], 
-                              y2=kinem['eil_z'][1], color='lightblue', alpha=0.2)
+        if ma.is_masked(kinem['eil_z'][0]) == False:
+            theta_ax.fill_between(x=(mintheta - 5, maxtheta + 5), y1=kinem['eil_z'][0], 
+                                y2=kinem['eil_z'][1], color='lightblue', alpha=0.2)
+    else:
+        #############################################################
+        ### CIN & 3CAPE W/HGT ###
+        #############################################################
+        cin_color, cape_color = 'teal', 'tab:orange'
+        #PLOT AXES/LOC
+        inflow_ax = plt.axes((1.141, -0.13, 0.0653, 0.23))
+        plt.figtext(1.175, 0.06, f'CIN & 3CAPE\n(J/kg)', weight='bold', color=gen_txt_clr, fontsize=12, ha='center', alpha=0.7)
+        inflow_ax.spines["top"].set_color(brdr_clr)
+        inflow_ax.spines["left"].set_color(brdr_clr)
+        inflow_ax.spines["right"].set_color(brdr_clr)
+        inflow_ax.spines["bottom"].set_color(brdr_clr)
+        inflow_ax.spines["bottom"].set_color(brdr_clr)   
+        inflow_ax.set_facecolor(bckgrnd_clr) 
+
+        mincin = intrp['cin_profileINTRP'][0:30].min()
+        max3cape = intrp['3cape_profileINTRP'][0:30].max()
+
+        #YTICKS
+        inflow_ax.set_ylim(intrp['zINTRP'][0], 3000)
+        inflow_ax.set_yticklabels([])
+        plt.ylabel(' ')
+        inflow_ax.tick_params(axis='y', length = 0)
+        inflow_ax.grid(True, axis='y')
+        inflow_ax.axvline(0, linestyle=':', alpha=.5)
+
+        #XTICKS
+        inflow_ax.set_xlim(mincin - 5, max3cape + 5)
+        inflow_ax.set_xticks([mincin, max3cape])
+        inflow_ax.set_xticklabels([int(mincin), int(max3cape)], weight='bold', alpha=0.5, fontstyle='italic', color=gen_txt_clr)
+
+        inflow_ax.tick_params(axis="x", direction="in", pad=-12)
+        inflow_ax.set_xlabel(' ')
+
+        #PLOT CIN / 3CAPE VS HGT
+        plt.fill_betweenx(intrp['zINTRP'], intrp['cin_profileINTRP'], color=cin_color, linewidth=0, alpha=0.5, clip_on=True)
+        plt.fill_betweenx(intrp['zINTRP'], intrp['3cape_profileINTRP'], color=cape_color, linewidth=0, alpha=0.8, clip_on=True)
+
+        if ma.is_masked(kinem['eil_z'][0]) == False:
+            inflow_ax.fill_between(x=(mincin - 5, max3cape + 5), y1=kinem['eil_z'][0],
+                                y2=kinem['eil_z'][1], color='lightblue', alpha=0.2)
     #################################################################
 
 

--- a/src/sounderpy/sounderpy.py
+++ b/src/sounderpy/sounderpy.py
@@ -206,7 +206,7 @@ def get_bufkit_data(model, station, fcst_hour, run_year=None, run_month=None, ru
 #########################################################################
 def build_sounding(clean_data, style='full', color_blind=False, dark_mode=False, storm_motion='right_moving',
                    special_parcels=None, show_radar=True, radar_time='sounding', map_zoom=2, modify_sfc=None,
-                   save=False, filename='sounderpy_sounding'):
+                   show_theta=False, save=False, filename='sounderpy_sounding'):
     
     '''
     Return a full sounding plot of SounderPy data, ``plt``
@@ -223,6 +223,7 @@ def build_sounding(clean_data, style='full', color_blind=False, dark_mode=False,
     :type storm_motion: str or list of floats, optional
     :param special_parcels: a nested list of special parcels from the ``ecape_parcels`` library. The nested list should be a list of two lists (`[[a, b], [c, d]]`) where the first list should include 'highlight parcels' and second list should include 'background parcels'. For more details, see the :ref:`parcels_logic` section.
     :type special_parcels: nested `list` of two `lists`, optional
+    :param show_theta: bool, optional
     :param save: whether to show the plot inline or save to a file. Default is ``False`` which displays the file inline.
     :type save: bool, optional
     :param filename: the filename by which a file should be saved to if ``save = True``. Default is `sounderpy_sounding`.
@@ -233,10 +234,11 @@ def build_sounding(clean_data, style='full', color_blind=False, dark_mode=False,
     
     print(f'> SOUNDING PLOTTER FUNCTION\n  ---------------------------------')
 
+    plt = __full_sounding(clean_data, color_blind, dark_mode, storm_motion, special_parcels, show_radar, radar_time, map_zoom, modify_sfc, show_theta)
     if save:
-        __full_sounding(clean_data, color_blind, dark_mode, storm_motion, special_parcels, show_radar, radar_time, map_zoom, modify_sfc).savefig(filename, bbox_inches='tight')
+        plt.savefig(filename, bbox_inches='tight')
     else:
-        __full_sounding(clean_data, color_blind, dark_mode, storm_motion, special_parcels, show_radar, radar_time, map_zoom, modify_sfc).show()
+        plt.show()
 
 
 


### PR DESCRIPTION
Here is an alternative to #33 which swaps the "Theta & Theta-e" plot with a "CIN & 3CAPE" inflow visualization. 

This version displays 3CAPE in place of CAPE on the right-hand side, which seems to be more useful in context with vorticity to evaluate low-level mesocyclone / tornado potential. 

For backwards compatibility, I also included a `show_theta` flag which restores the original theta / theta-e plot.

**Pros (compared to #33):**
* Better for analyzing low-level storm behavior
* Reduces "information overload" on the skew-T plot

**Cons (compared to #33):**
* Scaling is relative to min/max values rather than equivalent across all soundings
* Gives up the ability to see areas of mid- or upper-level convection (this could be visualized separately)

**Examples:**

Dark mode:

![image](https://github.com/user-attachments/assets/8804e0fd-87f8-46e0-a451-8ed126d25fd3)

Tornadic supercells:

![image](https://github.com/user-attachments/assets/ee08e0be-4393-4ff1-94cd-f0f1f02276bc)
![image](https://github.com/user-attachments/assets/03764b59-8bc2-4070-b8ca-82eefe5d887e)
![image](https://github.com/user-attachments/assets/04692ad7-e7a4-4754-8550-e3303c89ba95)

Elevated supercells:

![image](https://github.com/user-attachments/assets/24d8e3ba-548a-4319-ae91-fea27a7b7608)
![image](https://github.com/user-attachments/assets/f20fa931-9c6c-44c4-9fe4-2a4510dae410)

In-between cases (almost or slightly surface-based):

![image](https://github.com/user-attachments/assets/c8584225-d12d-4c3e-84cb-4efd45d7374f)
![image](https://github.com/user-attachments/assets/bec1fd1a-0d81-428f-b467-f1e54646d796)
